### PR TITLE
build(typescript): include all files need to be included

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "./node_modules/pkode/base-tsconfig.json",
-  "include": ["global.d.ts"]
+  "include": ["global.d.ts", "app/**/*.ts", "app/**/*.tsx"]
 }


### PR DESCRIPTION
since include property overrides the configuration in base-tsconfig.json
https://www.typescriptlang.org/tsconfig#extends